### PR TITLE
Rename stories to logbook entries

### DIFF
--- a/logbooks/models/pages.py
+++ b/logbooks/models/pages.py
@@ -41,7 +41,7 @@ class ImportantPages(BaseSetting):
     logbooks_index_page = models.ForeignKey(
         'logbooks.LogbookIndexPage', null=True, on_delete=models.SET_NULL, related_name='+')
     stories_index_page = models.ForeignKey(
-        'logbooks.StoryIndexPage', null=True, on_delete=models.SET_NULL, related_name='+')
+        'logbooks.StoryIndexPage', null=True, on_delete=models.SET_NULL, related_name='+', verbose_name="Logbook Entries Index Page")
 
     panels = [
         PageChooserPanel('logbooks_index_page'),


### PR DESCRIPTION
Though log book entires work as desired, slightly confusingly they are called Stories internally. This was a bit of an early specification problem. 

For the moment this clarifies this at the level of user interface, renaming them to Logbook Entry and Logbook Entries respectively.