### PR TITLE
Log entries are listed in reverse chronological order on log entries index

### DIFF
--- a/logbooks/models/pages.py
+++ b/logbooks/models/pages.py
@@ -86,7 +86,6 @@ class StoryPage(Page):
     class Meta:
         verbose_name = "Logbook Entry"
         verbose_name_plural = "Logbook Entries"
-        ordering = ['first_published_at']
 
     @classmethod
     def content_type_id(cls):


### PR DESCRIPTION
On log entries index page, list them in reverse chronological order, with the most recent entry at the top.

Internally these things are misnamed, but we are aware of that.

# Changes

## Before

<img width="824" alt="Screenshot 2021-10-11 at 17 38 24" src="https://user-images.githubusercontent.com/317734/136825411-55dc58b4-5fb4-483a-bb58-063c5aa7daa8.png">

## After

<img width="774" alt="Screenshot 2021-10-11 at 17 37 08" src="https://user-images.githubusercontent.com/317734/136825430-36b92278-9043-4d5d-a097-a7f2f1cdd87d.png">
