### PR TITLE
Fix scroll on Logbooks

### DIFF
--- a/smartforests/templates/base.html
+++ b/smartforests/templates/base.html
@@ -39,7 +39,7 @@
         {% endblock %}
     </head>
 
-    <body class="{% block body_class %}d-flex flex-column min-vh-100{% endblock %}">
+    <body class="d-flex flex-column {% block body_height %}min-vh-100 overflow-auto{% endblock %}{% block body_class %}{% endblock %}">
         {{ self.full_url|json_script:"routing_configuration" }} 
         {% wagtailuserbar %}
 

--- a/smartforests/templates/smartforests/map_page.html
+++ b/smartforests/templates/smartforests/map_page.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% load static ckbootstrap_tags %}
-{% block body_class %}d-flex flex-column vh-100 overflow-hidden{% endblock %}
+{% block body_height %}vh-100 overflow-hidden{% endblock %}
 {% block content %}
   <div data-mapbox-token="{{mapbox_token}}" id="MAP_APP" class='h-100 w-100 position-relative'></div>
 


### PR DESCRIPTION
The old template enforced overflow-hidden on all pages. This PR makes overflow-auto the default, and map_page.html now overrides that with overflow-hidden to achieve the 'full screen' effect for that specific page.