### PR TITLE
Remove duplicate metadata from logbook page template

### DIFF
--- a/logbooks/templates/logbooks/logbook_page.html
+++ b/logbooks/templates/logbooks/logbook_page.html
@@ -10,9 +10,6 @@
     {% endif %}
   </div>
   <div class="row gx-0">
-    <aside class='col-lg-2'>
-      {% include "logbooks/metadata.html" with page=self %}
-    </aside>
     <div class="row row-cols-1 gx-0 gy-7">
       {% for entry in child_list_page %}
       <article class="col">


### PR DESCRIPTION
Simple fix.

<img width="1293" alt="Screenshot 2021-10-28 at 12 56 10" src="https://user-images.githubusercontent.com/237556/139250970-22cf6e8e-dfe6-438a-8de0-e8dd1987c0b7.png">