### PR TITLE
Hotfix: Fix visual regression in tag size

### DIFF
--- a/logbooks/templates/logbooks/include/tag_label.html
+++ b/logbooks/templates/logbooks/include/tag_label.html
@@ -1,6 +1,6 @@
 <span class="badge rounded-pill text-mid-green caption align-baseline max-content {% if orientation == 'vertical' %}mb-2{% endif %} {% if tag_background_class %}{{ tag_background_class }}{% else %}bg-white{% endif %}">
   <a
-    class="text-reset text-decoration-none"
+    class="text-decoration-none"
     href="{{ settings.logbooks.ImportantPages.page_url.stories_index_page }}?tag={{ tag.name }}"
   >
     {{tag.name}}


### PR DESCRIPTION
After merge, tags are really big!

<img width="569" alt="Screenshot 2021-11-05 at 14 00 54" src="https://user-images.githubusercontent.com/317734/140522503-6d83bdb1-518d-4533-a765-a494d03db5af.png">

This fixes this, restoring this to working as expected.

<img width="539" alt="Screenshot 2021-11-05 at 13 59 32" src="https://user-images.githubusercontent.com/317734/140522577-648d65d5-d315-4f00-b4d0-12e17650d9a3.png">


