### PR TITLE
Fixes for layout regression on radio index page

### DIFF
--- a/logbooks/templates/logbooks/radio_index_page.html
+++ b/logbooks/templates/logbooks/radio_index_page.html
@@ -6,7 +6,7 @@
     <div>
       <main class="container-fluid">
         {% for episode in child_list_page %}
-          <div class="row g-0 border-sm-0 border-bottom pt-3 pb-2">
+          <div class="row g-0 border-sm-0 border-bottom pt-3 pb-2 {% if forloop.last %}mb-6{% endif %}">
             <div class="col d-flex align-items-start">
               {% include 'logbooks/include/episode_button.html' with episode=episode extra_classes="me-2 p-0 d-none d-md-block" %}
               <div>
@@ -35,7 +35,7 @@
                 </div>
               </div>
             </div>
-            <div class="col-2 align-items-start justify-content-end d-none d-md-flex">
+            <div class="col-2 d-none d-md-flex align-items-start justify-content-end">
               {% if episode.image %}
                   {% image episode.image height-60%}
               {% else %}
@@ -43,15 +43,6 @@
               {% endif %}
             </div>
           </div>
-        </div>
-        <div class="col-2 d-flex align-items-start justify-content-end">
-          {% if episode.image %}
-              {% image episode.image height-60%}
-            {% else %}
-            <img src="{% static "img/radio-icon.svg" %}"/>
-            {% endif %}
-        </div>
-      </div>
     {% endfor %}
   </main>
 </div>


### PR DESCRIPTION
Due to a faulty merge, the radio index page was broken. This fixes this.

# Screenshots

## Before 

![Sizzy-Desktop atlas smartforests net 09Nov 18 06](https://user-images.githubusercontent.com/317734/140980103-3df29c13-af01-4d68-9d03-100c72f98861.png)
![Sizzy-iPhone 8 atlas smartforests net 09Nov 18 06](https://user-images.githubusercontent.com/317734/140980127-24a8203f-297e-41d9-81ec-8ecba8dd4697.png)


## After

![Sizzy-Desktop localhost 09Nov 18 05](https://user-images.githubusercontent.com/317734/140980179-d13a6bd2-330e-43bf-86fa-7a5cf98c1298.png)
![Sizzy-iPhone 8 localhost 09Nov 18 05](https://user-images.githubusercontent.com/317734/140980204-df8f0d64-1a57-4c22-9d4e-4807085e44fe.png)