### PR TITLE
Translated tag sidepanel

### DIFF
--- a/logbooks/templates/logbooks/include/tag_label.html
+++ b/logbooks/templates/logbooks/include/tag_label.html
@@ -1,9 +1,11 @@
+{% load i18n %}
+
 <span class="filter-tag {% if orientation == 'vertical' %}mb-2{% endif %} {% if tag_background_class %}{{ tag_background_class }}{% else %}filter-tag-white{% endif %}">
   <a
     class="text-decoration-none"
     data-smartforests-sidepanel-open="#tagpanel-offcanvas"
     data-turbo-frame="tagpanel-turboframe"
-    href="/_tags/{{ tag.slug }}/"
+    href="/{{LANGUAGE_CODE}}/_tags/{{ tag.slug }}/"
   >
     {{tag.name}}
   </a>

--- a/logbooks/templates/logbooks/thumbnails/related_page_thumbnail.html
+++ b/logbooks/templates/logbooks/thumbnails/related_page_thumbnail.html
@@ -1,15 +1,21 @@
-<a class="mini-card mb-2 text-dark-green bg-white" href="{{page.link_url}}">
+<a class="overflow-hidden mini-card mb-2 text-dark-green bg-white" href="{{page.link_url}}">
   <div>
     {{page.title}}
   </div>
 
-  <span class="microcopy-small text-black">
-    {{page.label}}
-  </span>
+  <div class='d-flex flex-row justify-content-between'>
+    <span>
+      <span class="microcopy-small text-black flex">
+        <span>{{page.label}}</span>
+      </span>
 
-  {% if page.owner and show_owner is not False %}
-    <span class="d-inline-block microcopy-small text-mid-green">
-      {{page.owner.get_full_name}}
+      {% if page.owner and show_owner is not False %}
+        <span class="d-inline-block microcopy-small text-mid-green">
+          {{page.owner.get_full_name}}
+        </span>
+      {% endif %}
     </span>
-  {% endif %}
+
+    <span class="microcopy-small text-light-grey flex">{{page.locale.language_code}}</span>
+  </div>
 </a>

--- a/logbooks/views.py
+++ b/logbooks/views.py
@@ -22,7 +22,7 @@ def tag_panel(request, slug):
             'pages': (
                 (
                     page_type,
-                    page_type.for_tag(tag)
+                    set(map(lambda p: p.localized, page_type.for_tag(tag)))
                 )
                 for page_type
                 in page_types

--- a/smartforests/static/js/tag_cloud.js
+++ b/smartforests/static/js/tag_cloud.js
@@ -13,6 +13,8 @@ window.addEventListener("resize", () => {
 });
 
 const init = () => {
+  const { languageCode } = JSON.parse(document.getElementById('request-info').innerHTML)
+
   // Downsample the canvas to produce the pixelated effect.
   const PIXEL_SIZE = 32;
   const MOBILE_BREAKPOINT = 540;
@@ -183,7 +185,7 @@ const init = () => {
             .append("a")
             .attr("class", "related-tag")
             .attr("data-turbo-frame", sidepanelFrame)
-            .attr("href", (d) => `/_tags/${d.slug}/`)
+            .attr("href", (d) => `/${languageCode}/_tags/${d.slug}/`)
             .on("click", () => {
               if (sidepanel) {
                 const instance =

--- a/smartforests/templates/base.html
+++ b/smartforests/templates/base.html
@@ -44,6 +44,9 @@
         <script type="application/json" id="model-info">
           { "app_label": "{{self.content_type.app_label}}", "model": "{{ self.content_type.model }}" }
         </script>
+        <script type="application/json" id="request-info">
+          { "languageCode": "{{ LANGUAGE_CODE }}" }
+        </script>
         {% wagtailuserbar %}
 
         <div

--- a/smartforests/urls.py
+++ b/smartforests/urls.py
@@ -30,7 +30,6 @@ urlpatterns = [
     path('search/', search_views.SearchView.as_view(), name='search'),
     path("footnotes/", include(footnotes_urls)),
     path('_frame/<page_id>/', sf_views.frame_content),
-    path('_tags/<slug>/', logbook_views.tag_panel),
     path('_filters/', sf_views.filters_frame),
     # path('api/', include(rest.get_urls())),
     # path('__debug__/', include(debug_toolbar.urls)),
@@ -49,6 +48,7 @@ urlpatterns += [
 ]
 
 urlpatterns += i18n_patterns(
+    path('_tags/<slug>/', logbook_views.tag_panel),
     re_path(r'^', include(wagtail_urls)),
 )
 


### PR DESCRIPTION
Downstream from #54.

This PR dedupes pages listed in the tag sidepanel, picking the best possible locale to display.

# Before

Multiple translations of a page show up.

<img width="398" alt="Screenshot 2021-11-15 at 12 03 20" src="https://user-images.githubusercontent.com/237556/141779054-b8f834bb-8b28-4b69-aa0d-75424eef22cc.png">

# After

Only one translation, ideally in the request's locale, shows up.

<img width="396" alt="Screenshot 2021-11-15 at 12 02 17" src="https://user-images.githubusercontent.com/237556/141779066-0768feed-0645-46dc-b231-ab2efe28adfb.png">
