### PR TITLE
Radio player is loaded on all radio pages

### DIFF
--- a/smartforests/typescript/index.tsx
+++ b/smartforests/typescript/index.tsx
@@ -19,13 +19,20 @@ async function load() {
     model: string;
   };
 
-  if (modelInfo?.model?.toLowerCase() === "mappage") {
-    const { main } = await import("./map");
-    main();
+  const modelName = modelInfo?.model?.toLowerCase();
+
+  let main = () => {};
+
+  switch (modelName) {
+    case "mappage":
+      ({ main } = await import("./map"));
+      break;
+
+    case "radioindexpage":
+    case "episodepage":
+      ({ main } = await import("./radio"));
+      break;
   }
 
-  if (modelInfo?.model?.toLowerCase() === "radiopage") {
-    const { main } = await import("./radio");
-    main();
-  }
+  main();
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes issue #71.

Radio player was not initialised on all radio pages, due to inaccurate page detection.


## Motivation and Context

Fixes issue #71.

## How Can It Be Tested?

1. Check out this branch locally and boot it up.
2. Add a radio player episode.
3. Visit a radio player index page.
4. Click on the play button by the radio player. Observe that the radio begins playing.
5. Refresh the Atlas. Re-visit the radio player index page. Select an individual radio player episode.
6. Click on the large play button on this episode. Observe that the radio begins playing.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've checked the spec (e.g. Figma file) and documented any divergences.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I've updated the documentation accordingly.