### PR TITLE
Hide delete action (for non-superusers)

### DIFF
--- a/smartforests/wagtail_hooks.py
+++ b/smartforests/wagtail_hooks.py
@@ -1,10 +1,12 @@
+from django.utils.functional import cached_property
 from wagtail.core import hooks
+from wagtail.admin.widgets.button import ButtonWithDropdownFromHook
 
 
 @hooks.register('construct_page_action_menu')
 def customise_page_actions(menu_items, request, context):
     '''
-    Disallow non-admins from deleting pages
+    Disallow non-admins from deleting pages via the Page Editor
     '''
     if not request.user.is_superuser:
         try:
@@ -16,7 +18,7 @@ def customise_page_actions(menu_items, request, context):
             pass
 
     '''
-    Make 'publish' the default action in the editor UI.
+    Make 'publish' the default action in Page Editor
     '''
     try:
         for (index, item) in enumerate(menu_items):
@@ -26,3 +28,41 @@ def customise_page_actions(menu_items, request, context):
                 break
     except:
         pass
+
+
+@hooks.register('construct_page_listing_buttons')
+def remove_page_listing_button_item(buttons, page, page_perms, is_parent=False, context=None):
+    '''
+    Disallow non-admins from deleting pages via the listing
+    '''
+    if not context.request.user.is_superuser:
+        more_actions_dropdown = buttons.pop()
+        buttons.append(ButtonWithDropdownFromHookExcludingDelete(
+            more_actions_dropdown))
+    return buttons
+
+
+class ButtonWithDropdownFromHookExcludingDelete(ButtonWithDropdownFromHook):
+    template_name = 'wagtailadmin/pages/listing/_button_with_dropdown.html'
+
+    def __init__(self, base_class, **kwargs):
+        self.hook_name = base_class.hook_name
+        self.page = base_class.page
+        self.page_perms = base_class.page_perms
+        self.is_parent = base_class.is_parent
+        self.next_url = base_class.next_url
+
+        super().__init__(base_class.label, hook_name=base_class.hook_name, page=base_class.page,
+                         page_perms=base_class.page_perms, is_parent=base_class.is_parent, next_url=base_class.next_url, **kwargs)
+
+    @cached_property
+    def dropdown_buttons(self):
+        buttons = super().dropdown_buttons
+        try:
+            for (index, item) in enumerate(buttons):
+                if item.label == 'Delete':
+                    buttons.pop(index)
+                    break
+        except:
+            pass
+        return buttons


### PR DESCRIPTION
- Fixes #99
  - Users who are not superusers can no longer delete pages (via the Page Editor view or Page Listing view), which will prevent permanent erasure of data.
  - It turns out we *CAN* actually limit this to only LogbookPage, via `if context.page.specific_class is LogbookPage`, but I actually think it makes sense to prevent deletion across the board (for non-superusers) to preserve version history and rollback capability amongst the editorial team.
- It also prioritises 'Publish' as an action, to minimise moderation workflows, which mirrors the airsift implementation so might be the expected behaviour of the editor to the project admins.

## How Can It Be Tested?
- You'll need to be logged in as a non-superuser (you can create one) OR you can comment out the `.is_superuser` line in the commits to test.
- At the bottom of the page editor, you should not find a delete button.
- In the 'more' dropdown on the page listings, you should not find a delete button.

## How Will This Be Deployed?
- [X] Ensure that only CK and Jennifer have superuser permissions.

## Screenshots (if appropriate):
<img width="361" alt="Screenshot 2022-01-13 at 11 07 12" src="https://user-images.githubusercontent.com/237556/149319126-1d63e12a-6b19-4ae5-b373-f9dad90ea72d.png">
<img width="602" alt="Screenshot 2022-01-13 at 11 51 47" src="https://user-images.githubusercontent.com/237556/149325453-2aaf789c-ba6e-4707-825f-62423ded4f86.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I've checked the spec (e.g. Figma file) and documented any divergences.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I've updated the documentation accordingly.