### PR TITLE
StoryPage thumbnail only shows first image

### DIFF
--- a/logbooks/models/pages.py
+++ b/logbooks/models/pages.py
@@ -52,6 +52,18 @@ class StoryPage(ArticlePage):
     def cover_image(self):
         return self.image
 
+    def get_first_image_from_body(self):
+        images = self.body_images()
+        if len(images) > 0:
+            return images[0]
+        return None
+
+    def get_thumbnail_images(self):
+        image = self.get_first_image_from_body()
+        if image is not None:
+            return [image]
+        else:
+            return []
 
 class StoryIndexPage(IndexPage):
     '''


### PR DESCRIPTION
Fixes #70

## How Can It Be Tested?

- Create a `StoryPage` with two images in the Body section: you should see a thumbnail with only one image in the Story Index Page (after 15 seconds to allow regeneration of the thumbnail)
- Now remove one of the images — you should still see only one thumbnail (after 15 secs)
- Now remove the last image — you should see no thumbnail (after 15 secs)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've checked the spec (e.g. Figma file) and documented any divergences.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I've updated the documentation accordingly.
- [ ] Replace unused checkboxes with bullet points.