### PR TITLE
Refresh wagtailuserbar links on pageload

### DIFF
--- a/smartforests/templates/base.html
+++ b/smartforests/templates/base.html
@@ -42,7 +42,11 @@
     <body class="{% block body_height %}min-vh-100{% endblock %} {% block body_class %}{% endblock %} app-{{ self.content_type.app_label }} model-{{ self.content_type.model }}">
         {{ self.full_url|json_script:"routing_configuration" }}
         <script type="application/json" id="model-info">
-          { "app_label": "{{self.content_type.app_label}}", "model": "{{ self.content_type.model }}" }
+          { 
+            "app_label": "{{self.content_type.app_label}}",
+            "model": "{{ self.content_type.model }}",
+            "page_id": "{{ self.id }}"
+          }
         </script>
         <script type="application/json" id="request-info">
           { "languageCode": "{{ LANGUAGE_CODE }}" }

--- a/smartforests/typescript/index.tsx
+++ b/smartforests/typescript/index.tsx
@@ -7,7 +7,7 @@ document.addEventListener("turbo:load", async (event) => {
   load();
 });
 
-async function load() {
+function getModelInfo() {
   const modelInfoInDOM = document.getElementById("model-info");
 
   if (!modelInfoInDOM) {
@@ -17,9 +17,31 @@ async function load() {
   const modelInfo = JSON.parse(modelInfoInDOM.innerHTML) as {
     app_label: string;
     model: string;
+    page_id: string
   };
 
-  const modelName = modelInfo?.model?.toLowerCase();
+  return modelInfo
+}
+
+const PAGE_ID_REGEX = /pages\/[0-9]+/gim
+document.addEventListener("turbo:render", () => {
+  const btns = document.getElementById("wagtail-userbar-items")
+  // get the page ID from the HTML
+  const modelInfo = getModelInfo()
+  if (!modelInfo) return
+  // find all the anchor links
+  const links = btns.querySelectorAll<HTMLAnchorElement>("a[role='menuitem']");
+  // loop over them, replace `page/oldID/` with `page/newID/`
+  for (const link of links) {
+    link.setAttribute("href", link.href.replace(PAGE_ID_REGEX, `pages/${modelInfo.page_id}`));
+  }
+})
+
+async function load() {
+  const modelInfo = getModelInfo()
+  if (!modelInfo) return
+
+  const modelName = modelInfo.model?.toLowerCase();
 
   let modules: Array<() => void> = []
 


### PR DESCRIPTION
#132 fixed the wagtailuserbar not being clickable after Turbo Visits. However, it also froze the HTML so that the anchor links pointed to the originally loaded page. This commit refreshes the anchor links to point to the current page. Fixes #143

## How Can It Be Tested?

- Navigate through different pages, and check that the 'edit' button in the wagtail user bar (bottom right, circular icon) point to the right page.
- 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I've checked the spec (e.g. Figma file) and documented any divergences.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I've updated the documentation accordingly.