### PR TITLE
Fix image cropping in logbooks

### DIFF
--- a/logbooks/templates/logbooks/story_blocks/image.html
+++ b/logbooks/templates/logbooks/story_blocks/image.html
@@ -1,3 +1,3 @@
 {% load wagtailimages_tags %}
-{% image value.image fill-680x400-c100 class='img-fluid' %}
+{% image value.image min-680x400 class='img-fluid' %}
 <p class='fs-7 text-grey mt-3 mb-0'>{{ value.caption }}</p>


### PR DESCRIPTION
## Description
Change the way image renditions are generated in logbook entries and stories so that the aspect ratio of the source image is preserved.

This only changes logbook entries. For 'cover' images, etc we want to control the displayed aspect ration and respect the editor's choice of focal point in the wagtail admin.

## Motivation and Context
Fixes #81

## How Can It Be Tested?
Upload an image with a non-square aspect ratio. Observe that it is not cropped.

## How Will This Be Deployed?
The usual

## Screenshots (if appropriate):
<img width="810" alt="Screenshot 2022-02-02 at 17 47 38" src="https://user-images.githubusercontent.com/361391/152208939-877e9fdb-3254-4b1c-9d29-5ddec82a9ff0.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've checked the spec (e.g. Figma file) and documented any divergences.
- [x] My code follows the code style of this project.