### PR TITLE
Match index header to article header positioning

### DIFF
--- a/logbooks/templates/logbooks/index_page_base.html
+++ b/logbooks/templates/logbooks/index_page_base.html
@@ -26,8 +26,8 @@
 
 <div class="container-fluid mt-0 filter-page__content">
   <div class="mb-5">
-    <div class="index-header mt-4 mt-md-6">
-      <div id="sidebar-show" class="filters-reveal collapse-horizontal">
+    <div class="index-header mt-3 mt-md-7">
+      <div id="sidebar-show" class="col-md-3 filters-reveal collapse-horizontal">
         <div class="sidebar-sized">
           {% if self.relevant_tags %}
           <a class="btn btn-link p-0" href="#filters" data-bs-toggle="offcanvas" href="#filters" role="button" aria-controls="filters">

--- a/smartforests/scss/components.scss
+++ b/smartforests/scss/components.scss
@@ -166,7 +166,6 @@
   align-items: flex-end;
   display: flex;
   flex-direction: row;
-  height: 128px;
 
   @include media-breakpoint-down(md) {
     padding-top: #{map-get($spacers, 3)};


### PR DESCRIPTION
Minor visual tweak to the Index Page header.

## Description

Adjusts the position of the Index Page header.

## Motivation and Context

When navigating from an IndexPage to an ArticlePage, the header jumps around in an ugly way. We have a solidly standardised spacing and columnal system in Bootstrap, but we use it inconsistently! 

#### Before:

<img width="1144" alt="Screenshot 2022-02-03 at 19 02 41" src="https://user-images.githubusercontent.com/237556/152411315-b164a9f4-e351-4278-961c-3f6a43002001.png">
<img width="1142" alt="Screenshot 2022-02-03 at 19 01 50" src="https://user-images.githubusercontent.com/237556/152411308-fe4da13f-ddf2-4b03-8ade-0dc505a64c38.png">

#### After:

<img width="1142" alt="Screenshot 2022-02-03 at 19 01 47" src="https://user-images.githubusercontent.com/237556/152411298-d6b3c3b1-f532-4b8c-8367-4fbd6ec8d41c.png">
<img width="1142" alt="Screenshot 2022-02-03 at 19 01 50" src="https://user-images.githubusercontent.com/237556/152411308-fe4da13f-ddf2-4b03-8ade-0dc505a64c38.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I've checked the spec (e.g. Figma file) and documented any divergences.
- [X] My code follows the code style of this project.