### PR TITLE
renaming episode pages to radio in side panel when opening a tag

### DIFF
--- a/logbooks/models/pages.py
+++ b/logbooks/models/pages.py
@@ -81,6 +81,9 @@ class EpisodePage(ArticlePage):
     Episodes are individual items for the radio.
     '''
 
+    class Meta:
+        verbose_name_plural = "Radio"
+
     show_in_menus_default = True
     parent_page_types = ['logbooks.RadioIndexPage']
     icon_class = "icon-radio"
@@ -292,18 +295,18 @@ class ContributorPage(GeocodedMixin, ArticleSeoMixin, BaseLogbooksPage):
 
     user = models.ForeignKey(
         User,
-        null = True,
-        blank = True,
-        on_delete = models.SET_NULL,
-        related_name = 'contributor_pages'
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name='contributor_pages'
     )
 
-    byline=CharField(max_length = 1000, blank = True, null = True)
-    avatar=ForeignKey(CmsImage, on_delete = models.SET_NULL,
-                        null = True, blank = True)
-    bio=RichTextField(blank = True, null = True)
+    byline = CharField(max_length=1000, blank=True, null=True)
+    avatar = ForeignKey(CmsImage, on_delete=models.SET_NULL,
+                        null=True, blank=True)
+    bio = RichTextField(blank=True, null=True)
 
-    content_panels=[
+    content_panels = [
         FieldPanel('title', classname="full title"),
         FieldPanel('byline'),
         ImageChooserPanel('avatar'),


### PR DESCRIPTION


## Description
Added verbose_name_plural = 'Radio' to the Episode Page class. The text that appears on the side bar when you open a tag is 'Radio' instead of 'episode pages'

## Motivation and Context
This fixes issue #185 

## How Can It Be Tested?
Download this branch and run locally.  Create a radio episode page and a tag and link them together.
It should look like this:
<img width="1371" alt="Screenshot 2022-02-21 at 11 00 07" src="https://user-images.githubusercontent.com/43313455/154942457-e9ece8e4-7bef-4362-b5f4-7a06ec4be23d.png">




## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I've checked the spec (e.g. Figma file) and documented any divergences.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I've updated the documentation accordingly.
