### PR TITLE
Remove duplicate contributor fields from article editor UI

### DIFF
--- a/logbooks/models/mixins.py
+++ b/logbooks/models/mixins.py
@@ -198,32 +198,6 @@ class Person(models.Model):
         return Tag.objects.filter(logbooks_atlastag_items__content_object__in=self.edited_content_pages())
 
 
-class DescendantPageContributorMixin(BaseLogbooksPage):
-    '''
-    Common configuration for pages that want to track their contributors.
-    '''
-
-    class Meta:
-        abstract = True
-
-    def contributors(self):
-        '''
-        Return all the people who have contributed to this page,
-        and any descendant pages too.
-        '''
-        pages = self.get_descendants(inclusive=True)
-        return list(set([
-            revision.user
-            for revision in PageRevision.objects.filter(page__in=pages)
-        ]))
-
-    api_fields = [
-        APIField('contributors', serializer=UserSerializer(many=True)),
-    ]
-
-    content_panels = []
-
-
 class GeocodedMixin(BaseLogbooksPage):
     '''
     Common configuration for pages that want to track a geographical location.
@@ -436,8 +410,7 @@ class ArticlePage(IndexedStreamfieldMixin, ContributorMixin, ThumbnailMixin, Geo
         InlinePanel("footnotes", label="Footnotes"),
     ] + ContributorMixin.content_panels + GeocodedMixin.content_panels
 
-    content_panels = Page.content_panels + \
-        additional_content_panels + ContributorMixin.content_panels
+    content_panels = Page.content_panels + additional_content_panels
 
     api_fields = [
         APIField('tags'),

--- a/logbooks/models/pages.py
+++ b/logbooks/models/pages.py
@@ -19,7 +19,7 @@ from commonknowledge.wagtail.models import ChildListMixin
 from commonknowledge.django.cache import django_cached_model
 from wagtail.api import APIField
 from smartforests.util import flatten_list, group_by_title
-from logbooks.models.mixins import ArticlePage, ArticleSeoMixin, BaseLogbooksPage, ContributorMixin, DescendantPageContributorMixin, GeocodedMixin, IndexPage, Person, SeoMetadataMixin, ThumbnailMixin, SidebarRenderableMixin
+from logbooks.models.mixins import ArticlePage, ArticleSeoMixin, BaseLogbooksPage, ContributorMixin, GeocodedMixin, IndexPage, Person, SeoMetadataMixin, ThumbnailMixin, SidebarRenderableMixin
 from logbooks.models.snippets import AtlasTag
 from smartforests.models import CmsImage
 from logbooks.models.tag_cloud import TagCloud
@@ -172,13 +172,13 @@ class LogbookPage(RoutablePageMixin, SidebarRenderableMixin, ChildListMixin, Con
         FieldPanel('title', classname="full title"),
         FieldPanel('description'),
         FieldPanel('tags'),
-    ] + DescendantPageContributorMixin.content_panels + GeocodedMixin.content_panels + ContributorMixin.content_panels
+    ] + GeocodedMixin.content_panels + ContributorMixin.content_panels
 
     api_fields = [
         APIField('icon_class'),
         APIField('tags'),
         APIField('description'),
-    ] + DescendantPageContributorMixin.api_fields + GeocodedMixin.api_fields
+    ] + ContributorMixin.api_fields + GeocodedMixin.api_fields
 
     @classmethod
     def for_tag(cls, tag):


### PR DESCRIPTION
Removes the doubled up fields for contributors on the article editor page. Fixes #136

## How Can It Be Tested?

When you go to an article page and edit it, there should only be one of 'additional contributor' fields, not two identical ones.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've checked the spec (e.g. Figma file) and documented any divergences.
- [ ] My code follows the code style of this project.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I've updated the documentation accordingly.
- [ ] Replace unused checkboxes with bullet points.