### PR TITLE
Default to page 1 of the search results, to fix search "none found" issue

### DIFF
--- a/commonknowledge/wagtail/search/views.py
+++ b/commonknowledge/wagtail/search/views.py
@@ -91,7 +91,7 @@ class BasicSearchView(TemplateView):
 
     def get_context_data(self, **kwargs):
         scope = self.get_scope()
-        page_num = safe_to_int(self.request.GET.get('page', 3), 1)
+        page_num = safe_to_int(self.request.GET.get('page', 1), 1)
         search_results = self.do_search()
 
         paginator = Paginator(search_results or [], 25)


### PR DESCRIPTION
This looks like a typo that needed fixing. The search results was looking for page 3, instead of page 1, by default. The result was a "No pages found" error which crashed the search panel. Fixed!

## How Can It Be Tested?

Search should work on local now, and not before — especially not for search queries that produce less than three pages of  results.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've checked the spec (e.g. Figma file) and documented any divergences.
- [x] My code follows the code style of this project.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I've updated the documentation accordingly.
- [ ] Replace unused checkboxes with bullet points.