### PR TITLE
New, smaller text, sticky-bottom footer

### DIFF
--- a/smartforests/templates/base.html
+++ b/smartforests/templates/base.html
@@ -95,15 +95,7 @@
         {% endblock %}
 
         {% block footer %}
-        <div class="bg-panel bg-dark-green text-white links-white flex-grow-1">
-            <footer class="container-fluid fs-6 text">
-                <div class="row flex-column flex-lg-row py-4 py-md-5">
-                    <div class="col d-flex flex-column flex-md-row align-items-start align-items-md-start justify-content-end p-2-5">
-                        {% flat_menu 'footer' max_levels=1 show_menu_heading=False template="menus/footer.html" %}
-                    </div>
-                </div>
-            </footer>
-        </div>
+        {% flat_menu 'footer' max_levels=1 show_menu_heading=False template="menus/footer.html" %}
         {% endblock %}
         {% if self %}
         <div id="radioPlayer" data-turbo-permanent class="offcanvas offcanvas-bottom min-h-48px h-auto bg-dark-green border-0 drop-shadow-mid-green-glow" data-bs-scroll="true" data-bs-backdrop="false" tabindex="-1" aria-labelledby="radioPlayerLabel">

--- a/smartforests/templates/menus/footer.html
+++ b/smartforests/templates/menus/footer.html
@@ -1,14 +1,20 @@
 {% load menu_tags %}
-
-<div class="mb-3 container">
-  <div class="row gy-3 gy-md-4 gx-1 gx-md-2 gx-lg-3">
+<footer class="bg-panel bg-dark-green container-fluid py-3 px-4 mt-auto">
+  <div class="d-grid d-md-flex gap-2 gap-md-4 gap-lg-7 fs-7 font-monospace text-uppercase text-white links-white">
     {% for item in menu_items %}
-      <div class="col col-6 col-md-4 col-lg-3">
-        <a class="d-block d-md-inline-block me-3" href="{{ item.href }}" data-turbo="false">{{ item.text }}</a>
-      </div>
+    <a
+      class="text-decoration-none"
+      href="{{ item.href }}"
+      data-turbo="false"
+      >{{ item.text }}</a
+    >
     {% endfor %}
-    <div class='col col-6 col-md-4 col-lg-3'>
-      Site by <a class="footer-link" target="_blank" target="_blank" rel="noopener noreferrer" href="https://commonknowledge.coop">Common Knowledge</a>
-    </div>
+    <a
+      class="text-decoration-none""
+      target="_blank"
+      rel="noopener noreferrer"
+      href="https://commonknowledge.coop"
+      >Site by Common Knowledge</a
+    >
   </div>
-</div>
+</footer>


### PR DESCRIPTION
Closes #183

- Aligns with design
- Sticky footer positioning
- Also tidies up the HTML substantially

## Testing

- Ensure you have a footer set up at http://localhost:8000/admin/wagtailmenus/flatmenu/
- Go to a page like ContributorsIndexPage and verify that the footer is sticky
- Check the typography

## Screenshots

<img width="1680" alt="Screenshot 2022-03-10 at 13 22 09" src="https://user-images.githubusercontent.com/237556/157670772-cba68f0c-521b-4213-b5fe-93c9a0133bb3.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've checked the spec (e.g. Figma file) and documented any divergences.
- [x] My code follows the code style of this project.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I've updated the documentation accordingly.
- [ ] Replace unused checkboxes with bullet points.