### PR TITLE
Use previous d3 minor version

### DIFF
--- a/smartforests/static/js/tag_cloud.js
+++ b/smartforests/static/js/tag_cloud.js
@@ -1,5 +1,5 @@
 import webcola from "https://cdn.skypack.dev/webcola";
-import * as d3 from "https://cdn.skypack.dev/d3@7";
+import * as d3 from "https://cdn.skypack.dev/d3@7.6";
 import * as chroma from "https://cdn.skypack.dev/chroma-js";
 import debounce from "https://cdn.skypack.dev/lodash.debounce";
 import uniqBy from "https://cdn.skypack.dev/lodash.uniqby";


### PR DESCRIPTION
The Skypack build `https://cdn.skypack.dev/d3@7` is broken, so this PR rolls back to v7.6