### PR TITLE
Issue sf3/hide bulk delete button

### DIFF
--- a/commonknowledge/wagtail/templatetags/ckwagtail_tags.py
+++ b/commonknowledge/wagtail/templatetags/ckwagtail_tags.py
@@ -7,7 +7,6 @@ from django.utils.safestring import mark_safe
 from commonknowledge.helpers import safe_to_int
 from django import template
 
-
 register = template.Library()
 
 
@@ -52,3 +51,13 @@ def render_streamfield(context, value, *args, **kwargs):
         })
     Block.get_context = get_context
     return str(value)
+
+
+@register.simple_tag(takes_context=True)
+def bulk_action_classes(context):
+    request = context.get('request', None)
+    if not request.user.is_superuser:
+        return 'hide_serious'
+    else:
+        return ''
+

--- a/smartforests/static/admin.css
+++ b/smartforests/static/admin.css
@@ -1,0 +1,3 @@
+ul.bulk-actions-buttons.hide_serious .serious {
+  display: none;
+}

--- a/smartforests/templates/wagtailadmin/base.html
+++ b/smartforests/templates/wagtailadmin/base.html
@@ -1,0 +1,6 @@
+{% extends "wagtailadmin/base.html" %}
+{% load static %}
+
+{% block branding_logo %}
+    <img src="{% static 'img/logbooks.svg' %}" alt="Smart Forests Admin" width="80" style="transform: rotate(90deg);" />
+{% endblock %}

--- a/smartforests/templates/wagtailadmin/bulk_actions/footer.html
+++ b/smartforests/templates/wagtailadmin/bulk_actions/footer.html
@@ -1,0 +1,13 @@
+{% load ckwagtail_tags %}
+{% load i18n wagtailadmin_tags %}
+<section class="footer bulk-actions-choices hidden" data-bulk-action-footer aria-labelledby="bulk-actions-heading">
+    <h2 id="bulk-actions-heading" class="visuallyhidden">{% trans "Bulk actions" %}</h2>
+    <div class="footer__container">
+        {% include 'wagtailadmin/bulk_actions/select_all_checkbox_input.html' with parent=parent %}
+        <ul class="bulk-actions-buttons {% bulk_action_classes %}">{% bulk_action_choices app_label model_name %}</ul>
+        <span data-bulk-action-num-objects class="num-objects"></span>
+        {% if objects.has_other_pages %}
+            <button type="button" data-bulk-action-num-objects-in-listing class="num-objects-in-listing u-hidden">{{ select_all_obj_text }}</button>
+        {% endif %}
+    </div>
+</section>

--- a/smartforests/wagtail_hooks.py
+++ b/smartforests/wagtail_hooks.py
@@ -2,6 +2,8 @@ from django.utils.functional import cached_property
 from wagtail.core import hooks
 from wagtail.admin.widgets.button import ButtonWithDropdownFromHook
 from smartforests.views import RadioEpisodeChooserViewSet
+from django.utils.html import format_html
+from django.templatetags.static import static
 
 
 @hooks.register('construct_page_action_menu')
@@ -72,3 +74,11 @@ class ButtonWithDropdownFromHookExcludingDelete(ButtonWithDropdownFromHook):
 @hooks.register('register_admin_viewset')
 def register_person_chooser_viewset():
     return RadioEpisodeChooserViewSet('radio_episode_chooser', url_prefix='radio-episode-chooser')
+
+
+@hooks.register("insert_global_admin_css")
+def insert_global_admin_css():
+    return format_html(
+        '<link rel="stylesheet" type="text/css" href="{}">',
+        static("admin.css"),
+    )


### PR DESCRIPTION
## Description
Fixes [SF3-3]
This hides the delete button from the admin bulk actions toolbar - for non-superusers. This is cosmetic change, since delete permissions are already disallowed for non-superusers.

- Adds a new static css file for admin pages
- Overrides a Wagtail admin template
- Adds a templatetag

## Motivation and Context
This is very light-touch. It doesn't check permissions with any specificity - it just hides a scary button for certain user types *on all admin pages*.

## Screenshots (if appropriate):
![Screenshot from 2022-12-08 18-18-20](https://user-images.githubusercontent.com/4164774/206520075-a6aefb1d-d4d4-42c7-8bde-b05896db42ad.png)
