### PR TITLE
Insert noindex meta tag into turboframe templates

### DIFF
--- a/logbooks/templates/logbooks/content_entry/sidepanel.html
+++ b/logbooks/templates/logbooks/content_entry/sidepanel.html
@@ -1,5 +1,10 @@
 {% load ckdjango_tags ckbootstrap_tags wagtailcore_tags wagtailimages_tags %}
 
+
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 <turbo-frame id="sidepanel-turboframe">
   <div class="container gx-2 py-2 bg-yellow opacity-8" style="mix-blend-mode: multiply">
     <button

--- a/logbooks/templates/logbooks/frames/metadata.html
+++ b/logbooks/templates/logbooks/frames/metadata.html
@@ -1,5 +1,9 @@
 {% load ckdjango_tags ckbootstrap_tags static wagtailcore_tags %}
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 <turbo-frame id="metadata-turboframe">
   {% include "logbooks/metadata.html" with page=page interactive=interactive %}
 </turbo-frame>

--- a/logbooks/templates/logbooks/frames/tags.html
+++ b/logbooks/templates/logbooks/frames/tags.html
@@ -1,5 +1,9 @@
 {% load ckdjango_tags ckbootstrap_tags static wagtailcore_tags site_settings %}
 
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 <turbo-frame id="tagpanel-turboframe" class="d-flex flex-column h-100">
   <div class="offcanvas-header text-dark-green">
     <div>

--- a/smartforests/templates/smartforests/frames/filters.html
+++ b/smartforests/templates/smartforests/frames/filters.html
@@ -1,3 +1,7 @@
+<head>
+  <meta name="robots" content="noindex">
+</head>
+
 <turbo-frame id="filters">
   {% include "smartforests/include/tag_list.html" %}
 </turbo-frame>


### PR DESCRIPTION
Fixes SF3-14

## Description
This is not the most elegant solution, but I believe it's the quickest. 

- The meta tag only gets added to the head if the frame is accessed directly, at e.g. [https://atlas.smartforests.net/en-gb/_metadata/507/](url)
- Robust. Adding a meta tag can never break anything, it might just not work...
- Quick. A more abstract solution based on - for example, regex matching with the current pathname - might cover all present and future bases, but it looked like it would take longer to engineer (though there could be a super quick Django way to do this that I don't know about yet)