### PR TITLE
Issue SF3-16 - fix private pages visibility

### DIFF
--- a/commonknowledge/wagtail/models.py
+++ b/commonknowledge/wagtail/models.py
@@ -58,6 +58,10 @@ class ChildListMixin:
     def get_context(self, request, *args, **kwargs):
         context = super().get_context(request, *args, **kwargs)
         qs = self.get_child_list_queryset(request)
+
+        if request.user.is_anonymous:
+            qs = qs.public()
+
         filter = self.get_filters(request)
         sort = self.get_sort(request)
 

--- a/commonknowledge/wagtail/search/views.py
+++ b/commonknowledge/wagtail/search/views.py
@@ -17,6 +17,10 @@ class BasicSearchView(TemplateView):
 
     def get_queryset(self):
         qs = self.get_page_model().objects.live()
+
+        if self.request.user.is_anonymous:
+            qs = qs.public()
+            
         scope = self.get_scope()
 
         if scope is None:


### PR DESCRIPTION
Fixes SF3-16

## Description
Adds a conditional filter on querysets so that private content isn't shown to anonymous users.

- Request object is checked for "is_anonymous"
- If true, returns `qs.public()` instead of `qs`

## Motivation and Context
Private content is already unavailable (not accessible) to anonymous users. This change makes the private content non-searchable/listable, so it is completely hidden.

## How Can It Be Tested?
Manually
