### PR TITLE
WIP: SF3-5 - image formatting

### DIFF
--- a/smartforests/image_formats.py
+++ b/smartforests/image_formats.py
@@ -1,0 +1,4 @@
+from wagtail.images.formats import Format, register_image_format
+
+register_image_format(Format('responsive', 'Responsive',
+                      'richtext-image responsive', 'original'))

--- a/smartforests/image_formats.py
+++ b/smartforests/image_formats.py
@@ -1,4 +1,0 @@
-from wagtail.images.formats import Format, register_image_format
-
-register_image_format(Format('responsive', 'Responsive',
-                      'richtext-image responsive', 'original'))

--- a/smartforests/scss/utils.scss
+++ b/smartforests/scss/utils.scss
@@ -259,7 +259,10 @@
   transition: none !important;
 }
 
-.richtext-image.responsive {
+.richtext-image {
   max-width: 100%;
   height: auto;
+  &.full-width {
+    width: 100%;
+  }
 }

--- a/smartforests/scss/utils.scss
+++ b/smartforests/scss/utils.scss
@@ -258,3 +258,8 @@
 .no-transition {
   transition: none !important;
 }
+
+.richtext-image.responsive {
+  max-width: 100%;
+  height: auto;
+}


### PR DESCRIPTION
Fixes SF3-5

## Description
Images in RichText blocks have a display / format option - e.g. "align left". The built in format are based on fixed widths. 
This PR adds a "Responsive" format, in cases where you want to avoid (horizontal) overflow.
