### PR TITLE
SF3-6 - Limit richtext features on logbook index page

### DIFF
--- a/home/templates/home/information_page.html
+++ b/home/templates/home/information_page.html
@@ -6,7 +6,7 @@
   {% if page.cover_image %}
   <div class="container-fluid g-0">
     <div>
-      {% image page.cover_image height-500 class="img-fluid hero-img" %}
+      {% image page.cover_image original class="img-fluid hero-img" %}
     </div>
   </div>
   {% endif %}

--- a/logbooks/models/pages.py
+++ b/logbooks/models/pages.py
@@ -196,7 +196,7 @@ class LogbookPage(RoutablePageMixin, SidebarRenderableMixin, ChildListMixin, Con
 
     tags = ClusterTaggableManager(through=AtlasTag, blank=True)
     description = RichTextField(
-        features=['bold', 'italic', 'link', 'ol', 'ul', 'hr', 'code', 'blockquote'])
+        features=['bold', 'italic', 'link', 'ol', 'ul', 'hr', 'code', 'blockquote', 'h2', 'h3', 'h4'])
 
     seo_description_sources = SeoMetadataMixin.seo_description_sources + [
         "description"

--- a/logbooks/models/pages.py
+++ b/logbooks/models/pages.py
@@ -195,7 +195,8 @@ class LogbookPage(RoutablePageMixin, SidebarRenderableMixin, ChildListMixin, Con
             return static_file_absolute_url('img/mapicons/logbooks.png')
 
     tags = ClusterTaggableManager(through=AtlasTag, blank=True)
-    description = RichTextField()
+    description = RichTextField(
+        features=['bold', 'italic', 'link', 'ol', 'ul', 'hr', 'code', 'blockquote'])
 
     seo_description_sources = SeoMetadataMixin.seo_description_sources + [
         "description"


### PR DESCRIPTION
Fixes issue SF3-6

## Description
- Removes controls for adding media or embeds in the logbook index page description
- Doesn't change the underlying schema, so existing logbook index pages will still show media and embeds if already present.
- Removes pre-formatting of cover images on `InformationPages`