### PR TITLE
SF3-15 - Publish scheduled content automatically

### DIFF
--- a/.github/scheduled_jobs.yaml
+++ b/.github/scheduled_jobs.yaml
@@ -1,0 +1,14 @@
+name: Scheduled Jobs
+
+on:
+  schedule:
+    - cron: '*/30 * * * *'
+  workflow_dispatch:
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Publish scheduled content
+      run: |
+        curl https://atlas.smartforests.net/api/service/publish -H "Token: ${{ secrets.SERVICE_API_TOKEN }}"

--- a/commonknowledge/django/service.py
+++ b/commonknowledge/django/service.py
@@ -1,0 +1,16 @@
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
+from django.conf import settings
+import subprocess
+
+
+@api_view(['GET'])
+def publish(request):
+    if request.method == 'GET':
+        if 'Token' in request.headers and request.headers['Token'] == settings.SERVICE_API_TOKEN:
+            result = subprocess.run(
+                ["python", "manage.py", "publish_scheduled_pages"], stdout=subprocess.PIPE, text=True)
+            if (result.returncode == 0):
+                print("Finished running 'manage.py publish_scheduled_pages'")
+                return Response('OK', status=200)
+        return Response('Invalid token', status=403)

--- a/smartforests/settings/base.py
+++ b/smartforests/settings/base.py
@@ -320,3 +320,5 @@ WAGTAIL_CONTENT_LANGUAGES = LANGUAGES = [
 POSTHOG_DJANGO = {
     "distinct_id": lambda request: request.user and request.user.distinct_id
 }
+
+SERVICE_API_TOKEN = os.getenv("SERVICE_API_TOKEN")

--- a/smartforests/urls.py
+++ b/smartforests/urls.py
@@ -13,7 +13,8 @@ from django.conf.urls.i18n import i18n_patterns
 from django.views.generic import TemplateView
 from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView, SpectacularSwaggerView
 
-from commonknowledge.django import rest
+# from commonknowledge.django import rest
+from commonknowledge.django import service
 from .api import wagtail_api_router
 
 from search import views as search_views
@@ -32,7 +33,7 @@ urlpatterns = [
     path('_filters/', sf_views.filters_frame),
     path('favicon.ico',
          RedirectView.as_view(url='/static/img/favicon.png', permanent=True)),
-    # path('api/', include(rest.get_urls())),
+    # path('api/', include(rest.get_urls())),ScheduledPublishViewSet
     path('400', TemplateView.as_view(template_name='400.html')),
     path('403', TemplateView.as_view(template_name='403.html')),
     path('404', TemplateView.as_view(template_name='404.html')),
@@ -69,4 +70,8 @@ urlpatterns += i18n_patterns(
 
 urlpatterns += [
     re_path(r'', include(wagtail_content_import_urls)),
+]
+
+urlpatterns += [
+    path('api/service/publish', service.publish),
 ]


### PR DESCRIPTION
Fixes SF3-15

## Description
- Adds an endpooint `/api/service/publish` that runs `manage.py publish_scheduled_pages` in a subprocess
- Adds a github actions config, to hit the endpoint every 30 minutes, triggering publishing of any scheduled content that's reached its due date/time.

## How Can It Be Tested?
Endpoint can be tested locally, manually on a dev instance

## How Will This Be Deployed?
Before merging this:

- [ ] Add an env var to digital ocean app platform: `SERVICE_API_TOKEN=<token>`
- [ ] Add the same var `<token>` as a Github secret
