### PR TITLE
Ensure offcanvas is hidden when navigating back

### DIFF
--- a/smartforests/typescript/index.tsx
+++ b/smartforests/typescript/index.tsx
@@ -64,12 +64,15 @@ async function load() {
 }
 
 function resetJSForTurboFrame() {
-  // Ensure all Boostrap Offcanvases (sidepanels) are closed when the page opens
-  // which is necessary when navigating back in the Turbo Frame cache'd history
+  // Ensure Boostrap Offcanvases (sidepanels) are in the correct state
+  // according to the Turbo Frame cache'd history. If going back in the history
+  // and the Offcanvas was previously open, then re-open it
   const offcanvas = document.querySelectorAll(".offcanvas")
+
   for (const el of offcanvas) {
+    const visible = window.getComputedStyle(el)['visibility'] === 'visible'
     let offcanvas = new Offcanvas(el)
     offcanvas.show()
-    offcanvas.hide()
+    if (!visible) offcanvas.hide()
   }
 }

--- a/smartforests/typescript/index.tsx
+++ b/smartforests/typescript/index.tsx
@@ -1,10 +1,12 @@
 import "./sidepanel";
 import "./mainmenu";
+import { Offcanvas } from "bootstrap"
 
 load();
 
 document.addEventListener("turbo:load", async (event) => {
   load();
+  resetJSForTurboFrame();
 });
 
 function getModelInfo() {
@@ -28,7 +30,7 @@ document.addEventListener("turbo:render", () => {
   const btns = document.getElementById("wagtail-userbar-items")
   // get the page ID from the HTML
   const modelInfo = getModelInfo()
-  if (!modelInfo) return
+  if (!modelInfo || !btns) return
   // find all the anchor links
   const links = btns.querySelectorAll<HTMLAnchorElement>("a[role='menuitem']");
   // loop over them, replace `page/oldID/` with `page/newID/`
@@ -59,4 +61,15 @@ async function load() {
   }
 
   modules.forEach(fn => fn());
+}
+
+function resetJSForTurboFrame() {
+  // Ensure all Boostrap Offcanvases (sidepanels) are closed when the page opens
+  // which is necessary when navigating back in the Turbo Frame cache'd history
+  const offcanvas = document.querySelectorAll(".offcanvas")
+  for (const el of offcanvas) {
+    let offcanvas = new Offcanvas(el)
+    offcanvas.show()
+    offcanvas.hide()
+  }
 }


### PR DESCRIPTION
## Description

Manually re-initialises Offcanvas elements and closes them, so that they never appear to hang open.

## Motivation and Context

This was an issue because Turbo seems to have cached the HTML at the moment of navigation away from the page, with the offcanvas element open.

When one navigates back, it seems Boostrap didn't properly re-initialise the offcanvas — probably because it's not getting the Window events it needs to get going (Turbo gives its own events like `turbo:load` for these fake navigations).

So we help it along.