### PR TITLE
Stop tag cloud animation after 2 seconds

### DIFF
--- a/smartforests/static/js/tag_cloud.js
+++ b/smartforests/static/js/tag_cloud.js
@@ -446,6 +446,12 @@ const init = () => {
           updateBackground(realGraphNodes, links);
         })
       });
+
+      // Stop animation after converged
+      setTimeout(() =>{
+        cola.on("tick",null)
+      }, 2000)
+      
     };
 
     layout();


### PR DESCRIPTION
Fixes half of the tag cloud issue - drifting to the left.