### PR TITLE
Enqueue script with html5 audio processing

### DIFF
--- a/smartforests/static/js/radio_wagtailmedia.js
+++ b/smartforests/static/js/radio_wagtailmedia.js
@@ -1,0 +1,58 @@
+jQuery(function () {
+  // Get the duration of an imported audio file
+  let title, durationInput
+
+  const observer = new MutationObserver(function (mutations_list) {
+
+    mutations_list.forEach(() => {
+      var upload = jQuery(document).find('section#upload-audio')[0]
+      if (upload) {
+        // Hide the title, for better UX
+        title = jQuery(upload).find('input[name="media-chooser-upload-title"]').closest('li')
+        durationInput = jQuery(upload).find('input[name="media-chooser-upload-duration"]').closest('li')
+        title.hide()
+
+        // Disable & hide the duration input
+        durationInput.attr('disabled', true)
+        durationInput.hide()
+
+        observer.disconnect()
+      }
+    })
+
+    jQuery('input[name="media-chooser-upload-file"]').on('change', async function (evt) {
+      // Disable the submit button, just in case...
+      const submit = jQuery('button[type="submit"]')
+      submit.attr('disabled', true)
+
+      // Get the file and duration
+      const [file] = evt.target.files
+      const ctx = new AudioContext()
+      const buffer = await file.arrayBuffer()
+      const data = await ctx.decodeAudioData(buffer)
+
+      if (!!(data?.duration && !isNaN(data?.duration))) {
+        const duration = Math.floor(data.duration)
+
+        // Insert the duration into the input
+        durationInput.show()
+        jQuery('input[name="media-chooser-upload-duration"]').val(duration)
+
+        // Show and autofill the title
+        title.show()
+        jQuery('input[name="media-chooser-upload-title"]').val(file.name)
+
+      } else {
+        jQuery(document).find('input[name="media-chooser-upload-file"]').val(null)
+        alert("Something is wrong with that file, or it's the wrong file type. Supported formats are MP3, OGG or WAV")
+      }
+
+      // release the button
+      submit.attr('disabled', false)
+      observer.observe(document.querySelector('body'), { subtree: false, childList: true });
+    });
+
+  });
+
+  observer.observe(document.querySelector('body'), { subtree: false, childList: true });
+})

--- a/smartforests/wagtail_hooks.py
+++ b/smartforests/wagtail_hooks.py
@@ -82,3 +82,11 @@ def insert_global_admin_css():
         '<link rel="stylesheet" type="text/css" href="{}">',
         static("admin.css"),
     )
+
+
+@hooks.register("insert_global_admin_js", order=100)
+def global_admin_js():
+    return format_html(
+        '<script type="module" src="{}"></script>',
+        static("/js/radio_wagtailmedia.js")
+    )


### PR DESCRIPTION
Fixes SF3-17

The brief was to automate extracting the duration of the audio file, so it doesn't have to be done manually.

- Used the HTML5 [AudioContext ](https://developer.mozilla.org/en-US/docs/Web/API/BaseAudioContext/decodeAudioData)api to do the extraction. 
- Works with MP3, OGG and WAV
- Displays an alert and resets the input if there's an uncaught error from the input itself
- Alerts and resets if someone selects a non-audio file
- Disables the duration field 

Added extras:

- Autofills the title field from the name of the audio file
- Hides the duration field until a file is selected
- Hides the title field until a file is selected, giving a user the chance to benefit from the title autofill (minimise potential wasted time)

[Screencast from 2023-01-19 21-35-40.webm](https://user-images.githubusercontent.com/4164774/213554291-92176e80-bcc3-4f23-999b-73db1d902ea3.webm)


