### PR TITLE
Fix text breaking within words

### DIFF
--- a/smartforests/scss/components.scss
+++ b/smartforests/scss/components.scss
@@ -294,9 +294,7 @@
     margin-left: 15px;
     margin-right: 15px;
     font-size: 10.5px !important;
-    max-width: 120px;
-    overflow: hidden;
-    text-overflow: ellipsis;
+    max-width: max-content;
     transition: all 0.25s ease-in-out;
 
     &:hover {

--- a/smartforests/scss/overrides.scss
+++ b/smartforests/scss/overrides.scss
@@ -6,6 +6,7 @@ $small-font-size: $font-size-base * 0.7777777778;
   --cc-bg: #f9f9f9;
   --cc-btn-primary-bg: #026302;
 }
+
 @mixin body-text {
   font-size: 16px;
   font-weight: normal;
@@ -107,6 +108,7 @@ a.card {
     position: absolute;
     width: 100%;
     height: 100%;
+
     &:hover {
       background-color: transparentize($color: $dark-green, $amount: 0.9);
     }
@@ -199,6 +201,7 @@ a.card {
   border-left: none;
   box-shadow: 0px 0px 20px 0px rgba($dark-green, 0.2);
 }
+
 .text-reset {
   @include body-text;
 }
@@ -211,7 +214,7 @@ a.card {
   }
 }
 
-.content-copy > * + * {
+.content-copy>*+* {
   margin-top: map-get($map: $spacers, $key: 5);
 }
 
@@ -253,9 +256,11 @@ a.card {
 
   // Interaction
   cursor: pointer;
+
   &:hover {
     height: 16px;
   }
+
   transition: all 0.3s;
 }
 
@@ -265,7 +270,7 @@ html body .shadow-none.shadow-none {
 
 // For long links
 a {
-  word-break: break-all;
+  word-break: break-word;
 }
 
 .wagtail-userbar {


### PR DESCRIPTION

## Description
This PR changes the word break setting on long links and makes tag labels on atlas same width as text (overflow removed).

## Motivation and Context
Addresses issue [SF3-56](https://linear.app/commonknowledge/issue/SF3-56/fix-words-being-split-at-the-end-of-a-line)
