### PR TITLE
fix: dont display untranslated stories or radios

### DIFF
--- a/logbooks/models/mixins.py
+++ b/logbooks/models/mixins.py
@@ -417,6 +417,11 @@ class IndexPage(ChildListMixin, SeoMetadataMixin, BaseLogbooksPage):
     if not settings.DEBUG:
         max_count = 1
 
+    def get_child_list_queryset(self, *args, **kwargs):
+        return super().get_child_list_queryset().filter(
+            alias_of=None
+        )
+
     def get_filters(self, request):
         filter = {}
 

--- a/logbooks/models/pages.py
+++ b/logbooks/models/pages.py
@@ -436,6 +436,11 @@ class ContributorsIndexPage(IndexPage):
     class Meta:
         verbose_name = "Contributors index page"
 
+    # Default child list filters out untranslated pages, but
+    # we should always show all contributors
+    def get_child_list_queryset(self, *args, **kwargs):
+        return self.get_children().live().specific()
+
     def relevant_tags(self):
         return group_by_title(
             Tag.objects.filter(

--- a/logbooks/models/pages.py
+++ b/logbooks/models/pages.py
@@ -320,11 +320,6 @@ class LogbookIndexPage(IndexPage):
 
         return group_by_title(tags, key='name')
 
-    def get_child_list_queryset(self, *args, **kwargs):
-        return super().get_child_list_queryset().filter(
-            alias_of=None
-        )
-
     def get_filters(self, request):
         filter = {}
 


### PR DESCRIPTION
## Description
This moves the filter that removes untranslated child pages from the Logbooks index page to the generic Index page mixin. This means all index pages will not display untranslated content.

## Motivation and Context
Fixes issue https://linear.app/commonknowledge/issue/SF3-60/inconsistency-of-translation

## How Can It Be Tested?
The easiest way to test is to copy the live database and make sure the Stories, Radios and Logbook pages only display translated content.

## How Will This Be Deployed?
Standard deploy, but when we have deployed we will need to Unpublish the untranslated version of Indigenous Smart Forest Technologies, as this has been marked as translated (even though it is not).

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- I've checked the spec (e.g. Figma file) and documented any divergences.
- [x] My code follows the code style of this project.
- My change requires a change to the documentation.
- I've updated the documentation accordingly.
- Replace unused checkboxes with bullet points.