### PR TITLE
feat: add wagtail-localize option to use the DeepL machine translator

### DIFF
--- a/smartforests/settings/base.py
+++ b/smartforests/settings/base.py
@@ -329,3 +329,10 @@ WAGTAILLOCALIZE_JOBS = {
 
 USE_BACKGROUND_WORKER = os.getenv(
     "USE_BACKGROUND_WORKER", "False") in ("True", "true", True, 1, "t")
+
+WAGTAILLOCALIZE_MACHINE_TRANSLATOR = {
+    "CLASS": "wagtail_localize.machine_translators.deepl.DeepLTranslator",
+    "OPTIONS": {
+        "AUTH_KEY": os.getenv("DEEPL_AUTH_KEY"),
+    },
+}

--- a/smartforests/settings/dev.py
+++ b/smartforests/settings/dev.py
@@ -29,6 +29,10 @@ if USE_DEBUG_TOOLBAR:
         'debug_toolbar.middleware.DebugToolbarMiddleware',
     ]
 
+WAGTAILLOCALIZE_MACHINE_TRANSLATOR = {
+    "CLASS": "wagtail_localize.machine_translators.dummy.DummyTranslator",
+}
+
 try:
     from .local import *
 except ImportError:


### PR DESCRIPTION
## Description
Simply sets up Wagtail Localize to use DeepL for machine translation.

## Motivation and Context
Required to automatically translate content.

## How Can It Be Tested?
Create the following in `settings/local.py`:

```python
WAGTAILLOCALIZE_MACHINE_TRANSLATOR = {
    "CLASS": "wagtail_localize.machine_translators.deepl.DeepLTranslator",
    "OPTIONS": {
        "AUTH_KEY": "your_deepl_pro_auth_key"
    },
}
```

## How Will This Be Deployed?
We need to set the environment variable `DEEPL_AUTH_KEY` on the prod server.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- * I've checked the spec (e.g. Figma file) and documented any divergences.
- [x] My code follows the code style of this project.
- [ ] I've updated the documentation accordingly.
- * Replace unused checkboxes with bullet points.