### PR TITLE
feat: add translate tags command to automatically translate tags with DeepL

### DIFF
--- a/smartforests/management/commands/translate_tags.py
+++ b/smartforests/management/commands/translate_tags.py
@@ -1,0 +1,78 @@
+from django.core.management.base import BaseCommand
+from smartforests.models import Tag, User
+from wagtail.core.models.i18n import Locale
+from wagtail_localize.models import Translation, TranslationSource
+from wagtail_localize.views.edit_translation import machine_translate
+
+
+class MockRequest:
+
+    class MockMessage:
+        def add(self, *args, **kwargs):
+            pass
+
+    def __init__(self, user):
+        self.user = user
+        self.method = "POST"
+        self._messages = MockRequest.MockMessage()
+        self.POST = {
+            "next": "https://example.com"
+        }
+
+    def get_host(self):
+        return "example.com"
+
+
+class Command(BaseCommand):
+    help = 'Translate tags with WAGTAILLOCALIZE_MACHINE_TRANSLATOR'
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.admin = User.objects.filter(is_superuser=True).first()
+        self.mock_request = MockRequest(user=self.admin)
+
+    def handle(self, *args, **options):
+        tags = Tag.objects.all()
+        for tag in tags:
+            target_locales = Locale.objects.exclude(id=tag.locale.id)
+            print(f"{str(tag).title()}: ensuring translations")
+            self.ensure_translations(tag, target_locales)
+
+    def ensure_translations(self, tag, locales):
+        for locale in locales:
+            # Check if translation already exists
+            translated_tag = Tag.objects.filter(
+                translation_key=tag.translation_key,
+                locale=locale
+            ).first()
+
+            if not translated_tag:
+                print(f">>>> {locale}: translating")
+
+                # Create translated tag first, then update it (no other way)
+                translated_tag, _ = Tag.objects.get_or_create(
+                    name=tag.name,
+                    translation_key=tag.translation_key,
+                    locale=locale,
+                    defaults={
+                        "slug": tag.slug
+                    }
+                )
+
+                # Create translation
+                translation_source, _ = TranslationSource.get_or_create_from_instance(
+                    tag)
+                translation, _ = Translation.objects.get_or_create(
+                    source=translation_source, target_locale=locale)
+
+                # Update translation
+                machine_translate(self.mock_request, translation.id)
+
+                # Update tag
+                translation.save_target(user=self.admin, publish=True)
+
+                # Refresh from db to print translated tag
+                translated_tag.refresh_from_db()
+                print(f">>>> {locale}: translated to {translated_tag.name}")
+            else:
+                print(f">>>> {locale}: translation exists")

--- a/smartforests/settings/local.example.py
+++ b/smartforests/settings/local.example.py
@@ -1,0 +1,25 @@
+# Local settings go here
+# DO NOT import from base - it has already been imported in dev.py or production.py
+
+# local does not import from base, as it is imported from
+
+WAGTAILTRANSFER_SOURCES = {
+    'production': {
+        'BASE_URL': 'https://atlas.smartforests.net/admin/wagtail-transfer',
+        'SECRET_KEY': 'XXXXXX',
+    },
+}
+
+MAPBOX_API_PUBLIC_TOKEN = 'XXXXXX'
+MAPBOX_STYLE = 'XXXXXX'
+
+POSTHOG_PUBLIC_TOKEN = 'XXXXXX'
+
+MAP_WIDGETS = {
+    "MapboxPointFieldWidget": (
+        ("access_token", MAPBOX_API_PUBLIC_TOKEN),
+    ),
+    "MAPBOX_API_KEY": MAPBOX_API_PUBLIC_TOKEN
+}
+
+USE_BACKGROUND_WORKER = True


### PR DESCRIPTION
## Description
Adds a command, `python manage.py translate_tags`, that uses the configured machine translator
to translate all the tags that don't already have translations.

## Motivation and Context
Required because manually translating all the tags is not feasible.

## How Can It Be Tested?
Run the command locally, it should use the dummy translator, which reverses the word order of any tags with more
than one word (e.g. Amazon Rainforest).

## How Will This Be Deployed?
Normal method

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- I've checked the spec (e.g. Figma file) and documented any divergences.
- [x] My code follows the code style of this project.
- My change requires a change to the documentation.
- I've updated the documentation accordingly.
- Replace unused checkboxes with bullet points.