### PR TITLE
fix: deduplicate tag cloud and sidebar, and add untranslated content to sidebar

### DIFF
--- a/commonknowledge/wagtail/models.py
+++ b/commonknowledge/wagtail/models.py
@@ -30,16 +30,13 @@ class ChildListMixin:
     def get_sort(self, request):
         if len(self.sort_options) == 0:
             return None
-        if hasattr(self, 'page_type') and self.page_type == 'Logbook':
-            return next(
-                (
-                    opt for opt in self.sort_options
-                    if opt.slug == request.GET.get('sort')
-                ),
-                self.sort_options[1]
-            )
-        else:
-            return None
+        return next(
+            (
+                opt for opt in self.sort_options
+                if opt.slug == request.GET.get('sort')
+            ),
+            self.sort_options[0]
+        )
 
     def get_search_queryset(self, request, qs):
         q = request.GET.get('query')

--- a/logbooks/models/mixins.py
+++ b/logbooks/models/mixins.py
@@ -422,10 +422,7 @@ class IndexPage(ChildListMixin, SeoMetadataMixin, BaseLogbooksPage):
         # Sort by annotated field "is_current_locale" to show translated content first
         return get_result_class(self.__class__).objects.filter(
             id__in=child_ids
-        ).annotate(is_current_locale=ExpressionWrapper(
-            Q(locale__language_code=self.locale.language_code),
-            output_field=BooleanField()
-        )).order_by("-is_current_locale").specific()
+        ).specific()
 
     def get_filters(self, request):
         filter = {}


### PR DESCRIPTION
Simple deduplication fixes. There may be more at-source duplication that is possible, but
adding late-stage duplication fixes the issue, is easier to understand, and protects against
future bugs.

## Motivation and Context
Solves duplicated tags in the tag cloud, duplicated entries in the tag sidebar, and ensures
untranslated content is also visible in the sidebar.

## Test
Copy the database from the live server. Select a non-English locale and check the
home page tags are translated. Also check the side bar content has no duplicates
and includes translated content when possible.