### PR TITLE
Styled tag page, in case some one right clicks it

### DIFF
--- a/logbooks/models/mixins.py
+++ b/logbooks/models/mixins.py
@@ -46,6 +46,7 @@ from treebeard.mp_tree import get_result_class
 import requests
 from django.core.files.images import ImageFile
 from smartforests.mixins import SeoMetadataMixin
+from django.http import HttpResponseRedirect
 
 
 class BaseLogbooksPage(Page):
@@ -364,7 +365,10 @@ class SidebarRenderableMixin(BaseLogbooksPage):
         '''
 
         context = self.get_context(request)
-        return TemplateResponse(request, 'logbooks/content_entry/sidepanel.html', context)
+        if 'Turbo-Frame' in request.headers:
+            return TemplateResponse(request, 'logbooks/content_entry/sidepanel.html', context)
+        elif 'page' in context:
+            return HttpResponseRedirect(context['page'].url)
 
 
 class IndexPage(ChildListMixin, SeoMetadataMixin, BaseLogbooksPage):

--- a/logbooks/templates/logbooks/frames/tags.html
+++ b/logbooks/templates/logbooks/frames/tags.html
@@ -14,7 +14,9 @@
       <h5 class="offcanvas-title text-capitalize text-reset fw-bold mt-1" id="offcanvasLabel">{{tag.name}}</h5>
     </div>
     
-    <button type="button" class="btn-close text-reset" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+    {% if close is not False %}
+      <button type="button" class="btn-close text-reset" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+    {% endif %}
   </div>
 
   {% if tag.thumbnail %}

--- a/logbooks/templates/logbooks/standalone-views/tags.html
+++ b/logbooks/templates/logbooks/standalone-views/tags.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+{% load static ckdjango_tags ckbootstrap_tags %}
+{% block content %}
+  <div style="
+      max-width: 600px;
+      margin: 70px auto 0;
+      padding: 0px !important;
+  " class="logbook-entry-card border-2">
+    {% include "logbooks/frames/tags.html" with tags=tags pages=pages close=False %}
+  </div>
+{% endblock %}

--- a/logbooks/views.py
+++ b/logbooks/views.py
@@ -103,14 +103,25 @@ def tag_panel(request, slug):
         for (page_type, page_list) in pages_for_tag(tags, tag_panel_types)
     ]
 
-    return render(
-        request,
-        'logbooks/frames/tags.html',
-        {
-            'tag': tags[0],
-            'pages': pages
-        }
-    )
+    if 'Turbo-Frame' in request.headers:
+        return render(
+            request,
+            'logbooks/frames/tags.html',
+            {
+                'tag': tags[0],
+                'pages': pages
+            }
+        )
+    else:
+        # If not a turbo frame, we need to render it with page chrome
+        return render(
+            request,
+            'logbooks/standalone-views/tags.html',
+            {
+                'tag': tags[0],
+                'pages': pages
+            }
+        )
 
 
 def metadata(request, page_id, **kwargs):


### PR DESCRIPTION
If a user right-clicks a turbo link (a tag, or a map marker), they'll see a relatively unstyled Django template.

This PR adds a check for these tag turbo frame template routes and, if there is no sign that the request came from the Turbo JS library (i.e. no relevant header) then:

- For tags, it will render as a full page
- For map markers, the user will be redirected to the map marker's full page

<img width="1386" alt="Screenshot 2023-09-06 at 10 58 16" src="https://github.com/planetarypraxis/smartforests/assets/237556/47d44930-a193-4821-9e3f-a48bee48d0d4">
