### PR TITLE
fix: two filtering bugs, one to fix missing content, one to stop duplication

### DIFF
--- a/commonknowledge/wagtail/models.py
+++ b/commonknowledge/wagtail/models.py
@@ -71,6 +71,9 @@ class ChildListMixin:
                 qs = qs.filter(**filter)
             else:
                 qs = qs.filter(filter)
+            # Complex filters can introduce joins that create duplicate results
+            # Fix with distinct()
+            qs = qs.distinct()
 
         if sort:
             qs = qs.order_by(sort.ordering)

--- a/smartforests/util.py
+++ b/smartforests/util.py
@@ -31,6 +31,8 @@ def flatten_list(the_list):
 def ensure_list(list_or_el):
     if isinstance(list_or_el, list):
         return list_or_el
+    if isinstance(list_or_el, tuple):
+        return list(list_or_el)
     return [list_or_el, ]
 
 


### PR DESCRIPTION
## Description
1. The ensure_list function was converting a tuple into a list of tuples, instead of converting the tuple into a list. This was breaking some query filters.
2. Filtering the get_childlist_queryset() was returning duplicates for some queries. This is fixed by adding a distinct() call.

## How Can It Be Tested?
1. Visit http://localhost:8000/en/logbooks/?filter=biodiversity and check Logbooks are displayed.
2. Visit http://localhost:8000/en/stories/?filter=datafication and check there are no duplicates.

## How Will This Be Deployed?
Normal deployment (automatic).

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- I've checked the spec (e.g. Figma file) and documented any divergences.
- [x] My code follows the code style of this project.
- My change requires a change to the documentation.
- I've updated the documentation accordingly.
- Replace unused checkboxes with bullet points.