### PR TITLE
Update highlighting tags in text functionality so that it includes multi word and hyphenated tags

### DIFF
--- a/commonknowledge/wagtail/templatetags/ckwagtail_tags.py
+++ b/commonknowledge/wagtail/templatetags/ckwagtail_tags.py
@@ -101,17 +101,8 @@ def highlight_tags(context, content: SafeText):
     locale = Locale.get_active()
 
     content = str(content)
-
-    words = set()
-    splitter = r"[ !#()\-;:'\",./<>&]"
-    raw_words = re.split(splitter, content)
-
-    # Consider potential multi-word tags by combining adjacent words
-    for i in range(len(raw_words)):
-        for j in range(i + 1, len(raw_words) + 1):
-            phrase = " ".join(raw_words[i:j])
-            words.add(phrase)
-            words.add(phrase.lower())
+  
+    splitter = r"[ !#()\;:'\",./<>&]"
             
      
     # logger.info(f"Wordlist to highlight: {words}")


### PR DESCRIPTION
## Description
This PR updates the highlight_tags function so that it can match on multi word and hyphenated tags
 
## Motivation and Context
Addresses issue [SF3-158](https://linear.app/commonknowledge/issue/SF3-158/missing-in-text-tags)

## How Can It Be Tested?
Download the branch and run locally
Navigate to a logbook page
Add a multi word tag to the page (if there's not one already)
Add that tag text to the body content
Observe the multi word is highlighted
