### PR TITLE
Search and filter changes on mobile map

### DIFF
--- a/smartforests/scss/mapbox.scss
+++ b/smartforests/scss/mapbox.scss
@@ -59,6 +59,11 @@
 }
 
 .mapboxgl-ctrl-geocoder {
+
+  @include media-breakpoint-down(sm) {
+    width: 80% !important;
+  }
+  
   &--icon {
     fill: $dark-green !important;
   }
@@ -123,7 +128,7 @@
 
   &:not(.mapboxgl-ctrl-filters--collapsed) {
     height: 500px;
-    width: 100%;
+    width: 80%;
     max-height: calc(100vh - 130px);
   }
 }


### PR DESCRIPTION

## Description
This PR makes some CSS changes so that the search bar and filters popover are narrower on mobile
It also updates the filters popover so that clicking on a tag closes it

## Motivation and Context
Addresses issue [SF3-207](https://linear.app/commonknowledge/issue/SF3-207/search-and-filter-changes-on-mobile-map)

## How Can It Be Tested?
Download the branch and run locally
Go to the map page on mobile
Observe that clicking on a tag closes the filters popover 

## How Will This Be Deployed?
Normal deployment

